### PR TITLE
CE-1662-updated-release-flow-for-cent-button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules
 dist
+.idea

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ To manage which assets on your site are collectible using a friendly UI, add the
 ```
 
 Then, on Cent.co, you will see a **Manage Collectibles** button in the **Website** tab that launches a management interface _within_ your site.
+The management interface in the website is controlled by adding `?collectManager=1` to the url of your website.
+The optional parameter `preRelease` (full added parameter is `?collectManager=1&preRelease=1`) can be used to fetch the latest pending version of the SDK if available.
 
 ### Headless mode
 

--- a/src/button.ts
+++ b/src/button.ts
@@ -30,6 +30,9 @@ const manageButtonMap = {
   ...
  */
 };
+
+let showPreRelease = false;
+
 const MIN_DIM = 100;
 const hooks = [];
 relay.init(hooks);
@@ -47,6 +50,11 @@ function init() {
     } else {
       newExitButton();
       initManage();
+    }
+
+    const preRelease = getQueryVariable('preRelease');
+    if (preRelease) {
+      showPreRelease  = true;
     }
   }
   else {
@@ -362,7 +370,8 @@ function onClickManage(e) {
   e.stopPropagation();
   e.preventDefault();
   relay.manage(
-    this.getAttribute(attrs.ASSET_URL)
+    this.getAttribute(attrs.ASSET_URL),
+    showPreRelease
   );
 }
 

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -107,11 +107,12 @@ export async function collect(assetURL, assetTitle, assetDescription) {
   });
 }
 
-export async function manage(assetURL) {
+export async function manage(assetURL, showPreRelease) {
   await new Promise(waitForLoaded);
   showRelayIFrame();
   sendPostMessage(methods.MANAGE_ASSET, {
     assetURL,
+    showPreRelease,
   });
 }
 


### PR DESCRIPTION
not sure if having `showPreRelease` as a simple variable in `button.ts` is the best way to do this. happy to improve if you have any suggestions @chejazi :) 
This variable isn't security relevant or should be protected from users being able to see/manipulate it. 
If anyone goes into dev console and ends up finding it, I think they can manage with seeing the work-in-progress changes